### PR TITLE
Remove unnecessary code from the "AbstractCUser" class' "email" field

### DIFF
--- a/cuser/models.py
+++ b/cuser/models.py
@@ -2,7 +2,6 @@ from django.db import models
 from django.contrib.auth.models import (
     BaseUserManager, PermissionsMixin, AbstractBaseUser
 )
-from django.core import validators
 from django.core.mail import send_mail
 from django.utils import timezone
 
@@ -47,12 +46,7 @@ class AbstractCUser(AbstractBaseUser, PermissionsMixin):
     """
     email = models.EmailField(
         'email',
-        max_length=255,
         unique=True,
-        help_text='Required. 255 characters or fewer. Letters, digits, and @/./+/-/_ only.',
-        validators=[
-            validators.EmailValidator(),
-        ],
         error_messages={
             'unique': "A user with that email address already exists.",
         },


### PR DESCRIPTION
`EmailField`s have both of these characteristics out of the box (see [the documentation](https://docs.djangoproject.com/en/1.10/ref/models/fields/#emailfield)):
- A maximum length of 254 in order to be RFC3696/5321-compliant ([details](https://docs.djangoproject.com/en/1.10/releases/1.8/#default-emailfield-max-length-increased-to-254))
- Email validation

Thus, it's not necessary to include these in this app. Also, the help text did not list all of the characters that are acceptable in email addresses.
