### PR TITLE
Remove unnecessary code from the "AbstractCUser" class

### DIFF
--- a/cuser/models.py
+++ b/cuser/models.py
@@ -68,15 +68,11 @@ class AbstractCUser(AbstractBaseUser, PermissionsMixin):
     objects = CUserManager()
 
     USERNAME_FIELD = 'email'
-    REQUIRED_FIELDS = []
 
     class Meta:
         verbose_name = 'user'
         verbose_name_plural = 'users'
         abstract = True
-
-    def __str__(self):
-        return self.email
 
     def get_full_name(self):
         """


### PR DESCRIPTION
The code I removed in this commit is already in Django's `AbstractBaseUser` class, so it doesn't need to be here too:
1. [`REQUIRED_FIELDS`](https://github.com/django/django/blob/1.10.1/django/contrib/auth/base_user.py#L58)
2. [`__str__`](https://github.com/django/django/blob/1.10.1/django/contrib/auth/base_user.py#L73-L74)
