### PR TITLE
Fixed issues with the "UserAuthenticationForm" class

### DIFF
--- a/cuser/forms.py
+++ b/cuser/forms.py
@@ -1,5 +1,5 @@
 from django import forms
-from django.contrib.auth.forms import ReadOnlyPasswordHashField
+from django.contrib.auth.forms import AuthenticationForm, ReadOnlyPasswordHashField
 from django.contrib.auth import password_validation
 
 from cuser.models import CUser
@@ -7,21 +7,13 @@ from cuser.models import CUser
 
 class UserAuthenticationForm(AuthenticationForm):
 
-    error_messages = {
-        'invalid_login': "Invalid credentials."
-    }
-
     def __init__(self, *args, **kwargs):
-        kwargs.setdefault('label_suffix', '')
         super(UserAuthenticationForm, self).__init__(*args, **kwargs)
-        self.fields['username'].widget = forms.TextInput(attrs={
-            'placeholder': 'email',
-            'spellcheck': 'false',
-            'autofocus': ''
+        self.fields['username'].widget = forms.EmailInput(attrs={
+            'autofocus': '',
+            'maxlength': self.fields['username'].max_length,
         })
-        self.fields['password'].widget = forms.PasswordInput(attrs={
-            'placeholder': 'password',
-        })
+
 
 class UserCreationForm(forms.ModelForm):
     """


### PR DESCRIPTION
These are the issues:
1. The `AuthenticationForm` import was missing.
2. The `error_messages` dictionary was unnecessary because Django automatically has the `invalid_login` error message say the right thing. In the case of the `cuser` app, the `invalid_login` error message is "Please enter a correct email address and password. Note that both fields may be case-sensitive.". Also, because the `error_messages` dictionary didn't have `inactive` in it, it was possible to end up with a `KeyError`.
3. The remaining changes (removing the blanking out of the `label_suffix`, removing the `placeholder` attributes, etc.) were made because, in my opinion, I think it would be best to stick with what the README says, which is that the only difference between CUser and the vanilla Django User is email address is the `USERNAME_FIELD` (and username does not exist). I know this is your app so you are, of course, free to do whatever you want with it. But the code that I removed was code that introduced differences that, to me, seem outside the scope of this app. Again, this is your app, so you are most definitely free to reject this pull request!
