### PR TITLE
fix user.get_email() call

### DIFF
--- a/cuser/admin.py
+++ b/cuser/admin.py
@@ -147,7 +147,7 @@ class UserAdmin(admin.ModelAdmin):
         adminForm = admin.helpers.AdminForm(form, fieldsets, {})
 
         context = {
-            'title': _('Change password: %s') % escape(user.get_email()),
+            'title': _('Change password: %s') % escape(user.email),
             'adminForm': adminForm,
             'form_url': form_url,
             'form': form,


### PR DESCRIPTION
Without this commit you can't load the change password form in the django admin interface.