### PR TITLE
Custom db table name

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -119,6 +119,30 @@ model (also named ``Group``). This is useful if you want Django's default
 ``Group`` model to appear in the same part of the admin as CUser's ``CUser``
 model.
 
+Change default table name
+-------------------------
+
+By default Django gives the default table name in data base for each model.
+In our case it is equal to ``cuser_cuser``. If you want to change it you need
+to add ``db_table`` value to ``CUSER`` dictionary in your settings file.
+For instance, when you add:
+
+.. code-block:: python
+
+    CUSER = {
+        ...
+        'db_table': 'users',
+    }
+
+And run  the following after that:
+
+.. code-block:: shell
+
+       python manage.py makemigrations cuser
+       python manage.py migrate
+
+your table name for custom user model will be equal to ``users``
+
 Notes
 -----
 

--- a/cuser/models.py
+++ b/cuser/models.py
@@ -1,4 +1,5 @@
 from django.db import models
+from django.conf import settings
 from django.contrib.auth.models import (
     BaseUserManager, PermissionsMixin, AbstractBaseUser
 )
@@ -113,6 +114,7 @@ class CUser(AbstractCUser):
     """
     class Meta(AbstractCUser.Meta):
         swappable = 'AUTH_USER_MODEL'
+        db_table = settings.CUSER_SETTINGS['db_table']
 
 
 class Group(BaseGroup):

--- a/cuser/models.py
+++ b/cuser/models.py
@@ -114,7 +114,9 @@ class CUser(AbstractCUser):
     """
     class Meta(AbstractCUser.Meta):
         swappable = 'AUTH_USER_MODEL'
-        db_table = settings.CUSER_SETTINGS['db_table']
+
+        if settings.CUSER.get('db_table') is not None:
+            db_table = settings.CUSER['db_table']
 
 
 class Group(BaseGroup):

--- a/cuser/settings.py
+++ b/cuser/settings.py
@@ -4,7 +4,6 @@ from django.utils.translation import ugettext_lazy as _
 CUSER_SETTINGS = {
     'app_verbose_name': _("Custom User"),
     'register_proxy_auth_group_model': False,
-    'db_table': 'cuser',
 }
 
 if hasattr(settings, 'CUSER'):

--- a/cuser/settings.py
+++ b/cuser/settings.py
@@ -4,6 +4,7 @@ from django.utils.translation import ugettext_lazy as _
 CUSER_SETTINGS = {
     'app_verbose_name': _("Custom User"),
     'register_proxy_auth_group_model': False,
+    'db_table': 'cuser',
 }
 
 if hasattr(settings, 'CUSER'):


### PR DESCRIPTION
Sometimes we need to have a custom DB table name instead of default `cuser_cuser`. This PR will help in this case.